### PR TITLE
[skip ci] Add traversaro and Tobias-Fischer to mantainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,3 +50,5 @@ about:
 extra:
   recipe-maintainers:
     - seanyen
+    - traversaro
+    - Tobias-Fischer


### PR DESCRIPTION
I noticed that this package is a dependency of both ROS and robotology packages, and it has a single non-active mantainer. I opened this PR to add myself and @Tobias-Fischer (please let me know if this is ok) to the mantainers in case we need this in the future, as we need to wait the usual week before merging. @wolfv 


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
