### PR TITLE
[sdl2] Add .pc file generation in Windows and copy sdl2_compat.pc to sdl2.pc for compatibility with old pkg-config used in conda-forge

### DIFF
--- a/recipe/385.patch
+++ b/recipe/385.patch
@@ -1,0 +1,132 @@
+From 569368ade43f03ad4238845074db9cf844ae1324 Mon Sep 17 00:00:00 2001
+From: Anonymous Maarten <anonymous.maarten@gmail.com>
+Date: Mon, 24 Feb 2025 18:38:58 +0100
+Subject: [PATCH] cmake: also generate and install sdl2.pc on MSVC
+
+---
+ CMakeLists.txt | 91 ++++++++++++++++++++++++++------------------------
+ 1 file changed, 48 insertions(+), 43 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d36d82f..eb1d0b6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -558,53 +558,58 @@ if(SDL2COMPAT_INSTALL)
+   endforeach()
+   install(FILES "${PROJECT_BINARY_DIR}/include/SDL2/SDL_revision.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/SDL2")
+ 
+-  if(NOT MSVC)
+-    if(WIN32)
+-      set(SDL_CFLAGS "")
+-      set(SDL_RLD_FLAGS "")
+-      set(SDL_LIBS "-lmingw32 -lSDL2main -lSDL2 -mwindows")
+-      set(SDL_STATIC_LIBS "-lshell32")
+-    elseif(APPLE)
+-      set(SDL_CFLAGS "-D_THREAD_SAFE")
+-      set(SDL_LIBS "-lSDL2main -lSDL2 -Wl,-framework,Cocoa")
+-      set(SDL_STATIC_LIBS "")
+-      set(SDL_RLD_FLAGS "")  # !!! FIXME: this forces rpath, which we might want?
+-    else() # unix
+-      set(SDL_CFLAGS "-D_GNU_SOURCE=1 -D_REENTRANT")
+-      set(SDL_RLD_FLAGS "")  # !!! FIXME: this forces rpath, which we might want?
+-      set(SDL_LIBS "-lSDL2")
++  if(MSVC)
++    set(SDL_CFLAGS "")
++    set(SDL_RLD_FLAGS "")
++    set(SDL_LIBS "-lSDL2main -lSDL2")
++    set(SDL_STATIC_LIBS "-lshell32")
++  elseif(MINGW)
++    set(SDL_CFLAGS "")
++    set(SDL_RLD_FLAGS "")
++    set(SDL_LIBS "-lmingw32 -lSDL2main -lSDL2 -mwindows")
++    set(SDL_STATIC_LIBS "-lshell32")
++  elseif(APPLE)
++    set(SDL_CFLAGS "-D_THREAD_SAFE")
++    set(SDL_RLD_FLAGS "")  # !!! FIXME: this forces rpath, which we might want?
++    set(SDL_LIBS "-lSDL2main -lSDL2 -Wl,-framework,Cocoa")
++    set(SDL_STATIC_LIBS "")
++  else() # unix
++    set(SDL_CFLAGS "-D_GNU_SOURCE=1 -D_REENTRANT")
++    set(SDL_RLD_FLAGS "")  # !!! FIXME: this forces rpath, which we might want?
++    set(SDL_LIBS "-lSDL2")
++    set(SDL_STATIC_LIBS "")
++    foreach(lib ${CMAKE_DL_LIBS})
++      set(SDL_STATIC_LIBS "-l${lib}")
++    endforeach()
++    if(NOT SDL2COMPAT_STATIC)
+       set(SDL_STATIC_LIBS "")
+-      foreach(lib ${CMAKE_DL_LIBS})
+-        set(SDL_STATIC_LIBS "-l${lib}")
+-      endforeach()
+-      if(NOT SDL2COMPAT_STATIC)
+-        set(SDL_STATIC_LIBS "")
+-      endif()
+     endif()
++  endif()
+ 
+-    # !!! FIXME: do we _want_ static builds?
+-    if(SDL2COMPAT_STATIC)
+-      set(ENABLE_STATIC_TRUE "")
+-      set(ENABLE_STATIC_FALSE "#")
+-    else()
+-      set(ENABLE_STATIC_TRUE "#")
+-      set(ENABLE_STATIC_FALSE "")
+-    endif()
+-    set(ENABLE_SHARED_TRUE "")
+-    set(ENABLE_SHARED_FALSE "#")
++  # !!! FIXME: do we _want_ static builds?
++  if(SDL2COMPAT_STATIC)
++    set(ENABLE_STATIC_TRUE "")
++    set(ENABLE_STATIC_FALSE "#")
++  else()
++    set(ENABLE_STATIC_TRUE "#")
++    set(ENABLE_STATIC_FALSE "")
++  endif()
++  set(ENABLE_SHARED_TRUE "")
++  set(ENABLE_SHARED_FALSE "#")
+ 
+-    configure_file(sdl2_compat.pc.in sdl2_compat.pc @ONLY)
+-    install(FILES ${CMAKE_BINARY_DIR}/sdl2_compat.pc
+-      DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+-    )
++  configure_file(sdl2_compat.pc.in sdl2_compat.pc @ONLY)
++  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sdl2_compat.pc"
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
++  )
+ 
+-    configure_file("${CMAKE_SOURCE_DIR}/sdl2-config.in" "${CMAKE_BINARY_DIR}/sdl2-config" @ONLY)
+-    install(PROGRAMS "${CMAKE_BINARY_DIR}/sdl2-config" DESTINATION "${CMAKE_INSTALL_BINDIR}")
++  configure_file(sdl2-config.in "${CMAKE_CURRENT_BINARY_DIR}/sdl2-config" @ONLY)
++  install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/sdl2-config" DESTINATION "${CMAKE_INSTALL_BINDIR}")
+ 
+-    # uninstall
+-    configure_file(cmake/cmake_uninstall.cmake.in cmake_uninstall.cmake IMMEDIATE @ONLY)
++  # uninstall
++  if(NOT TARGET uninstall)
++    configure_file(cmake/cmake_uninstall.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake" IMMEDIATE @ONLY)
+     add_custom_target(uninstall
+-            COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
++      COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+   endif()
+ 
+   set(SOEXT ${CMAKE_SHARED_LIBRARY_SUFFIX})
+@@ -613,8 +618,8 @@ if(SDL2COMPAT_INSTALL)
+     install(CODE "
+       execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
+         \"lib${SONAME}${SOPOSTFIX}${SOEXT}\" \"libSDL2${SOPOSTFIX}${SOEXT}\"
+-        WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}\")")
+-    install(FILES ${CMAKE_BINARY_DIR}/libSDL2${SOPOSTFIX}${SOEXT} DESTINATION "${CMAKE_INSTALL_LIBDIR}")
++        WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\")")
++    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libSDL2${SOPOSTFIX}${SOEXT} DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+   endif()
+ 
+   install(FILES "${PROJECT_SOURCE_DIR}/sdl2.m4" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/aclocal")
+@@ -631,7 +636,7 @@ if(SDL2COMPAT_INSTALL)
+     set(CPACK_PROJECT_CONFIG_FILE "${PROJECT_BINARY_DIR}/CPackProjectConfig.cmake")
+     # CPACK_SOURCE_PACKAGE_FILE_NAME must end with "-src" (so we can block creating a source archive)
+     set(CPACK_SOURCE_PACKAGE_FILE_NAME "SDL${PROJECT_VERSION_MAJOR}-${PROJECT_VERSION}-src")
+-    set(CPACK_PACKAGE_DIRECTORY "${CMAKE_BINARY_DIR}/dist")
++    set(CPACK_PACKAGE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/dist")
+     include(CPack)
+   endif()
+ endif()

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -14,3 +14,8 @@ if errorlevel 1 exit 1
 :: Install!
 cmake --install build --config Release --prefix "%LIBRARY_PREFIX%"
 if errorlevel 1 exit 1
+
+:: Add sdl.pc to support old pkg-config
+:: See https://github.com/libsdl-org/sdl12-compat/issues/162 and
+:: https://github.com/libsdl-org/sdl2-compat/issues/381
+copy %LIBRARY_PREFIX%\lib\pkgconfig\sdl2_compat.pc %LIBRARY_PREFIX%\lib\pkgconfig\sdl2.pc

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,3 +8,8 @@ cmake --build build --config Release
 
 # Install
 cmake --install build --config Release --prefix $PREFIX
+
+# Add sdl.pc to support old pkg-config
+# See https://github.com/libsdl-org/sdl12-compat/issues/162 and
+# https://github.com/libsdl-org/sdl2-compat/issues/381
+cp $PREFIX/lib/pkgconfig/sdl2_compat.pc $PREFIX/lib/pkgconfig/sdl2.pc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,12 @@ package:
 source:
   url: https://github.com/libsdl-org/sdl2-compat/releases/download/release-{{ version }}/sdl2-compat-{{ version }}.tar.gz
   sha256: b559c734f2cdc4ea34266a1ef7724cbf3a729deaab23a774aa60a980368f5a88
+  patches:
+    # backport https://github.com/libsdl-org/sdl2-compat/pull/385
+    - 385.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
@@ -42,6 +45,8 @@ test:
     - sdl2-config --version  # [not win]
     - ./test_version.sh      # [unix]
     - ./test_version.bat     # [win]
+    - pkg-config --exists sdl2
+    - pkg-config --exists sdl2_compat
 
 about:
   home: https://www.libsdl.org/index.php


### PR DESCRIPTION
Fix https://github.com/conda-forge/sdl-feedstock/issues/22, partially by backporting https://github.com/libsdl-org/sdl2-compat/pull/385 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
